### PR TITLE
Check in designs

### DIFF
--- a/evaluation/syntax/_template.md
+++ b/evaluation/syntax/_template.md
@@ -1,0 +1,58 @@
+- Name: (fill me in: `name-of-design`)
+- Proposed by: [@name](link to github profile)
+- Original proposal (optional): (url)
+
+# Design
+
+<!-- Please fill out the snippets labeled with "fill me in". If there are any
+other examples you want to show, please feel free to append more.-->
+
+## base (reference)
+
+<!-- This is the snippet which is being translated to various scenarios we're
+translating from. Please keep this as-is, so we can reference it later.-->
+
+```rust
+/// A trimmed-down version of the `std::Iterator` trait.
+pub trait Iterator {
+    type Item;
+    fn next(&mut self) -> Option<Self::Item>;
+    fn size_hint(&self) -> (usize, Option<usize>);
+}
+
+/// An adaptation of `Iterator::find` to a free-function
+pub fn find<I, T, P>(iter: &mut I, predicate: P) -> Option<T>
+where
+    I: Iterator<Item = T> + Sized,
+    P: FnMut(&T) -> bool;
+```
+
+## always async
+
+<!-- A variant where all items are always `async` -->
+
+```rust
+// fill me in
+```
+
+## maybe async
+
+<!-- A variant where all items are generic over `async` -->
+
+```rust
+// fill me in
+```
+
+## generic over all modifier keywords
+
+<!-- A variant where all items are generic over all modifier keywords (e.g.
+`async`, `const`, `gen`, etc.) -->
+
+```rust
+// fill me in
+```
+
+# Notes
+
+<!-- Add additional notes, context, and thoughts you want to share about your design
+here -->

--- a/evaluation/syntax/progress-report-feb-2023.md
+++ b/evaluation/syntax/progress-report-feb-2023.md
@@ -1,0 +1,90 @@
+- Name: `progress-report-feb-2023`
+- Proposed by: [@yoshuawuyts](https://github.com/yoshuawuyts) and [@oli-obk](https://github.com/oli-obk)
+- Original proposal: [Keyword Generics Progress Report: February 2023 | Inside Rust Blog](https://blog.rust-lang.org/inside-rust/2023/02/23/keyword-generics-progress-report-feb-2023.html)
+
+# Design
+
+<!-- Please fill out the snippets labeled with "fill me in". If there are any
+other examples you want to show, please feel free to append more.-->
+
+## base (reference)
+
+<!-- This is the snippet which is being translated to various scenarios we're
+translating from. Please keep this as-is, so we can reference it later.-->
+
+```rust
+/// A trimmed-down version of the `std::Iterator` trait.
+pub trait Iterator {
+    type Item;
+    fn next(&mut self) -> Option<Self::Item>;
+    fn size_hint(&self) -> (usize, Option<usize>);
+}
+
+/// An adaptation of `Iterator::find` to a free-function
+pub fn find<I, T, P>(iter: &mut I, predicate: P) -> Option<T>
+where
+    I: Iterator<Item = T> + Sized,
+    P: FnMut(&T) -> bool;
+```
+
+## always async
+
+<!-- A variant where all items are always `async` -->
+
+```rust
+pub trait async Iterator {
+    type Item;
+    async fn next(&mut self) -> Option<Self::Item>;
+    fn size_hint(&self) -> (usize, Option<usize>);
+}
+
+pub async fn find<I, T, P>(iter: &mut I, predicate: P) -> Option<T>
+where
+    I: async Iterator<Item = T> + Sized,
+    P: async FnMut(&T) -> bool;
+```
+
+## maybe async
+
+<!-- A variant where all items are generic over `async` -->
+
+```rust
+pub trait ?async Iterator {
+    type Item;
+    ?async fn next(&mut self) -> Option<Self::Item>;
+    fn size_hint(&self) -> (usize, Option<usize>);
+}
+
+pub ?async fn find<I, T, P>(iter: &mut I, predicate: P) -> Option<T>
+where
+    I: ?async Iterator<Item = T> + Sized,
+    P: ?async FnMut(&T) -> bool;
+```
+
+## generic over all modifier keywords
+
+<!-- A variant where all items are generic over all modifier keywords (e.g.
+`async`, `const`, `gen`, etc.) -->
+
+*A slight modification from the report, using `effect` instead of `?effect`.*
+
+```rust
+pub trait effect Iterator {
+    type Item;
+    effect fn next(&mut self) -> Option<Self::Item>;
+    fn size_hint(&self) -> (usize, Option<usize>);
+}
+
+pub effect fn find<I, T, P>(iter: &mut I, predicate: P) -> Option<T>
+where
+    I: effect Iterator<Item = T> + Sized,
+    P: effect FnMut(&T) -> bool;
+```
+
+# Notes
+
+This is the original design proposed by the Keyword Generics Initiatve in the
+Feb 2023 Progress Report.
+
+<!-- Add additional notes, context, and thoughts you want to share about your design
+here -->


### PR DESCRIPTION
This checks in the base template outlined in https://github.com/rust-lang/keyword-generics-initiative/issues/10#issuecomment-1445253191, and includes the design we proposed in the progress report.

I figured this would be a better way to start collecting designs than just comments in a thread, so I'll go ahead and merge this sooner. That way we at least start getting a somewhat consistent picture of the various proposed designs, and we can always choose to update this later on.