### PR TITLE
Add a section on auto-concurrency

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -15,6 +15,7 @@
     - [Postfix question mark](./evaluation/syntax/postfix-question-mark.md)
     - [Where effect bounds](./evaluation/syntax/where-effect-bounds.md)
   - [Pattern Types and Backwards Compatibility](./evaluation/pattern-types.md)
+  - [Auto Concurrency](./evaluation/auto-concurrency.md)
 - [📚 Draft RFCs](./explainer/README.md)
   - [1. Effect-Generic Trait Declarations](./explainer/effect-generic-trait-declarations.md)
   - [2. Effect-Generic Bounds and Functions](./explainer/effect-generic-bounds-and-functions.md)

--- a/evaluation/auto-concurrency.md
+++ b/evaluation/auto-concurrency.md
@@ -60,7 +60,7 @@ async fn make_dinner() -> SomeResult<Meal> {
         let (veggies, meat) = (veggies_fut, meat_fut).join().await?;
         Dish::new(&[veggies, meat]).await
     };
-    let (dish, oven) = (dish_fut, preheat_oven(350)).join().await;
+    let (dish, oven) = (dish_fut, preheat_oven(350)).try_join().await?;
     oven.cook(dish, Duration::from_mins(3 * 60)).await
 }
 ```
@@ -178,14 +178,13 @@ desugar into the same code.
 ```rust
 /// A manual concurrent implementation using Rust 1.76 today.
 async fn make_dinner() -> SomeResult<Meal> {
-    use futures_concurrency::prelude::*;
     let dish_fut = {
         let veggies_fut = chop_vegetables();
         let meat_fut = marinate_meat();
         let (veggies, meat) = (veggies_fut, meat_fut).join().await?;
         Dish::new(&[veggies, meat]).await
     };
-    let (dish, oven) = (dish_fut, preheat_oven(350)).join().await;
+    let (dish, oven) = (dish_fut, preheat_oven(350)).try_join().await?;
     oven.cook(dish, Duration::from_mins(3 * 60)).await
 }
 

--- a/evaluation/auto-concurrency.md
+++ b/evaluation/auto-concurrency.md
@@ -60,7 +60,7 @@ async fn make_dinner() -> SomeResult<Meal> {
         Dish::new(&[veggies, meat]).await
     };
     let (dish, oven) = (dish_fut, preheat_oven(350)).join().await;
-    oven.cook(dish, Duration::mins(3 * 60)).await
+    oven.cook(dish, Duration::from_mins(3 * 60)).await
 }
 ```
 
@@ -94,8 +94,8 @@ async fn make_dinner() -> SomeResult<Meal> {
     async let meat = marinate_meat();
     async let oven = preheat_oven(350);
 
-    async let dish = Dish(ingredients: [veggies.await?, meat.await?]);
-    oven.await.cook(dish.await, Duration::mins(3 * 60)).await
+    async let dish = Dish(&[veggies.await?, meat.await?]);
+    oven.await.cook(dish.await, Duration::from_mins(3 * 60)).await
 }
 ```
 
@@ -136,8 +136,8 @@ fn make_dinner() -> SomeResult<Meal> {
     async let meat = marinate_meat();
     async let oven = preheat_oven(350);
 
-    async let dish = Dish(ingredients: [veggies.await?, meat.await?]);
-    oven.await.cook(dish.await, Duration::mins(3 * 60)).await
+    async let dish = Dish(&[veggies.await?, meat.await?]);
+    oven.await.cook(dish.await, Duration::from_mins(3 * 60)).await
 }
 ```
 
@@ -151,8 +151,8 @@ fn make_dinner() -> SomeResult<Meal> {
     let meat = marinate_meat();
     let oven = preheat_oven(350);
 
-    let dish = Dish(ingredients: [veggies?, meat?]);
-    oven.cook(dish, Duration::mins(3 * 60))
+    let dish = Dish(&[veggies?, meat?]);
+    oven.cook(dish, Duration::from_mins(3 * 60))
 }
 ```
 

--- a/evaluation/auto-concurrency.md
+++ b/evaluation/auto-concurrency.md
@@ -168,6 +168,17 @@ would also work. It would, however, be by far the most convenient way of
 creating parity between both contexts. As well as make async Rust code that much
 easier to read.
 
+## A note on syntax
+
+An earlier version of this document proposed using `.co.await`, `.co_await`,
+just `.co` or some other keyword to take the place of `async let` to indicate a
+concurrent `.await` can happen. The feasibility of syntax like that is not
+clear; though there would likely be distinct benefits to preserving the postfix
+nature of existing notations. Any further exploration of this direction should
+consider alternate syntaxes to `async let`. In particular as concurrent
+execution of `for await` loops is something that's also desirable, and would
+likely want syntax parity with concurrent execution of futures.
+
 ## Conclusion
 
 In this document we describe a mechanism inspired by Swift's `async let`

--- a/evaluation/auto-concurrency.md
+++ b/evaluation/auto-concurrency.md
@@ -167,9 +167,9 @@ easier to read.
 
 This is not the first proposal to suggest an `async let` notation for async
 Rust; to our knowledge that would be Conrad Ludgate in their [async let blog
-post](https://conradludgate.com/posts/async-let). However the didn't seem to
-mention Swift's work on the topic, and just like Swift it was based on the idea
-of multi-threaded tasks - not Rust's lightweight futures primitive.
+post](https://conradludgate.com/posts/async-let). However just like in Swift it
+was based on the idea of managed multi-threaded tasks - not Rust's unmanaged,
+lightweight futures primitive.
 
 A version of this is likely possible for multi-threaded code too; ostensibly via
 some kind of `par` keyword (`par let` / `par async let` / `par for await..in`).

--- a/evaluation/auto-concurrency.md
+++ b/evaluation/auto-concurrency.md
@@ -1,0 +1,107 @@
+# Auto Concurrency
+
+Async Rust brings [three unique capabilities to
+Rust](https://blog.yoshuawuyts.com/why-async-rust/): the ability to apply ad-hoc
+concurrency, the ability to arbitrarily pause, cancel and resume operations, and
+finally the ability to combine these capabilities into new ones - such as ad-hoc
+timeouts. Async Rust also does one other thing: it decouples "concurrency" from
+"parallelism" - while in non-async Rust both are coupled into the "thread"
+primitive.
+
+One challenge however is to make use of these capabilities. People notoriously
+struggle to use cancellation correctly, and are often caught off guard that
+computations after being suspended at an `.await` point may not necessarily be
+resumed ("cancelled"). Similarly: users will often struggle to apply
+fine-grained concurrency in their applications - because it fundamentally means
+exploding sequential control-flow sequences into Directed Acyclic control-flow
+Graphs (control-flow DAGs).
+
+## By Example: Swift
+
+Swift has introduced the `async let` keyword to enable linear-looking
+control-flow which statically expands to a concurrent DAG backed by tasks. To
+see how this works we can reference
+[SE-304](https://github.com/apple/swift-evolution/blob/main/proposals/0304-structured-concurrency.md)'s
+example which provides a `makeDinner` routine:
+
+```swift
+func makeDinner() async throws -> Meal {
+  async let veggies = chopVegetables()
+  async let meat = marinateMeat()
+  async let oven = preheatOven(temperature: 350)
+
+  let dish = Dish(ingredients: await [try veggies, meat])
+  return await oven.cook(dish, duration: .hours(3))
+}
+```
+
+The following constraints and operations occur here:
+
+- constraint: `dish` depends on `veggies` and `meat`.
+- concurrency: `veggies`, `meat`, and `oven` are computed concurrently
+- constraint: `Meal` depends on `oven` and `dish`
+- concurrency: `oven` and `dish` are computed concurrently
+
+In Swift the `async let` syntax automatically spawns tasks and ensures that they
+resolve when they need to - occasionally it will even implicitly insert `await`
+points where needed (e.g. `oven` is never explicitly `await`ed). We can
+translate this to Rust using the [`futures-concurrency`
+library](https://docs.rs/futures-concurrency) without having to use parallel
+tasks - just concurrent futures. That would look like this:
+
+```rust
+use futures_concurrency::prelude::*;
+
+async fn make_dinner() -> SomeResult<Meal> {
+    let dish_fut = {
+        let veggies_fut = chop_vegetables();
+        let meat_fut = marinate_meat();
+        let (veggies, meat) = (veggies_fut, meat_fut).join().await?;
+        Dish::new(&[veggies, meat]).await
+    };
+    let (dish, oven) = (dish_fut, preheat_oven(350)).join().await;
+    oven.cook(dish, Duration::mins(3 * 60)).await
+}
+```
+
+Compared to Swift the control-flow here is much harder to tease apart. We've
+accurately described our concurrency DAG; but reversing it to understand
+_intent_ has suddenly become a lot harder. Programmers generally have a better
+time understanding code when it can be read sequentially; and so it's no
+surprise that the Swift version is better at stating intent.
+
+## Auto-concurrency for Rust's Async Effect Contexts
+
+Rust's async system differs a little from Swift's, but only in the details. The
+main differences as it comes to what we'd want to do here are two-fold:
+
+1. Swift's async primitive are tasks: which are managed, parallel async
+   primitives. In Rust it's `Future`, which is unmanaged and not parallel by
+   default - it's only concurrent.
+2. In Rust all `.await` points have to be explicit and should not be omitted.
+   This is because as mentioned earlier: functions may permanently yield control
+   flow at `.await` points, and so they have to be called out in the source code.
+
+For this reason we can't quite do what Swift does - but I believe we could
+probably do something similar. From a language perspective, it seems like it
+should be possible to do a similar system using `async let` and `.await` - but
+where we statically analyze the control-flow graph to figure out where to
+implement the right concurrent `.await` points. An example:
+
+```rust
+async fn make_dinner() -> SomeResult<Meal> {
+    async let veggies = chop_vegetable();
+    async let meat = marinate_meat();
+    async let oven = preheat_oven(350);
+
+    async let dish = Dish(ingredients: [veggies.await?, meat.await?]);
+    oven.await.cook(dish.await, Duration::mins(3 * 60)).await
+}
+```
+
+This would achieve something very similar to
+
+## References
+
+- [Swift SE-0304: Structured Concurrency](https://github.com/apple/swift-evolution/blob/main/proposals/0304-structured-concurrency.md)
+- [Conrad Ludgate: Async Let - A New Concurrency Primitive?](https://conradludgate.com/posts/async-let)


### PR DESCRIPTION
This adds an analysis and evaluation of Swift's `async let` mechanism (SE-0304), how we could introduce that to async Rust, and how that would extend to `#[maybe(async)]` code. 

This PR does not yet detail a concrete proposal since I believe this should probably go through WG Async first. But questions related to maybe-async and concurrency have come up a number of times now, so I figured we should check in a document describing a potential resolution to that issue. Thanks!

[Rendered](https://github.com/rust-lang/keyword-generics-initiative/blob/auto-concurrency/evaluation/auto-concurrency.md)